### PR TITLE
Import remark as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process'
+import {remark} from 'remark'
 import {createUnifiedLanguageServer} from 'unified-language-server'
 
 process.title = 'remark-language-server'
@@ -8,6 +9,6 @@ createUnifiedLanguageServer({
   ignoreName: '.remarkignore',
   packageField: 'remarkConfig',
   pluginPrefix: 'remark',
-  plugins: ['remark-parse', 'remark-stringify'],
+  processor: remark,
   rcName: '.remarkrc'
 })

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "index.js"
   ],
   "dependencies": {
+    "remark": "^14.0.0",
     "unified-language-server": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Previously `remark-parse` and `remark-stringify` were loaded as plugins. Now remark is loaded as a regular dependency. The difference is that the language server now uses its own bundled remark version instead of relying on these plugins being available in the workspace.

This means the language server now doesn’t show an error if `remark-parse` or `remark-stringify` isn’t available in the workspace. This is mostly notable if the language server is started automatically by a language client in a project which doesn’t use remark.

<!--do not edit: pr-->
