### PR TITLE
Update `unified-language-server`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ createUnifiedLanguageServer({
   ignoreName: '.remarkignore',
   packageField: 'remarkConfig',
   pluginPrefix: 'remark',
-  plugins: ['remark-parse', 'remark-stringify'],
+  processorName: 'remark',
+  processorSpecifier: 'remark',
   rcName: '.remarkrc'
 })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "index.js"
   ],
   "dependencies": {
-    "unified-language-server": "^1.0.0"
+    "unified-language-server": "^2.0.0"
   },
   "devDependencies": {
     "prettier": "^2.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`remark-language-server` embraces the new features of `unified-language-server`. `processorName` and `processorSpecifier` are defined, so remark is loaded from the local `node_modules`.

<!--do not edit: pr-->
