### PR TITLE
Remove support for Node.js 14

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ consume this package.
 ## Install
 
 This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-In Node.js (version 14.14+, 16.0+, or 18.0+), install with [npm][]:
+In Node.js (version 16.0+, or 18.0+), install with [npm][]:
 
 ```sh
 npm install remark-language-server
@@ -116,7 +116,7 @@ Visual Studio Code.
 
 Projects maintained by the unified collective are compatible with all maintained
 versions of Node.js.
-As of now, that is Node.js 14.14+, 16.0+, and 18.0+.
+As of now, that is Node.js 16.0+, and 18.0+.
 Our projects sometimes work with older versions, but this is not guaranteed.
 
 ## Contribute


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Remove support for Node.js 14.

<!--do not edit: pr-->
