### PR TITLE
Document `ignorePath` and `ignorePathResolveFrom` settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,11 @@ This language server supports the following settings:
 
 * `remark.requireConfig` (`boolean`, default: `false`) — If true, only perform
   actions if a [configuration file][configuration-file] is found.
+* `remark.ignorePath` (`string`, optional) — Filepath to an ignore file to load.
+  When relative, it is resolved from the workspace folder.
+* `remark.ignorePathResolveFrom` (`'cwd' | 'dir'`, default: `'dir'`) — Resolve
+  patterns in `ignorePath` from the workspace folder (`'cwd'`) or the ignore
+  file’s folder (`'dir'`).
 
 ## Examples
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Documents the `remark.ignorePath` and `remark.ignorePathResolveFrom` settings exposed once unifiedjs/unified-language-server#73 lands, mirroring `unified-engine`'s ignore-path options. Part of remarkjs/vscode-remark#142.

<!--do not edit: pr-->
